### PR TITLE
feat(global): :sparkles: Added the correct subtitle

### DIFF
--- a/components/SiteHead.tsx
+++ b/components/SiteHead.tsx
@@ -1,11 +1,11 @@
 import Head from "next/head"
-
+import { TITLES } from '../lib/constants';
 
 //TODO: get the <Meta> content attribute controlled at Sanity level?
 function SiteHead() {
   return (
     <Head>
-      <title>Native Bound Unbound</title>
+      <title>{TITLES.title}</title>
       <meta name="description" content="" /> 
       <link rel="icon" href="/favicon.ico" />
     </Head>

--- a/components/SiteTitle.tsx
+++ b/components/SiteTitle.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import classNames from 'classnames/bind';
 import titles from '../styles/component/Title.module.scss';
 import TitleText  from './TitleText';
+import { TITLES } from '../lib/constants'
 
 let cx = classNames.bind(titles);
 
@@ -30,7 +31,7 @@ const SiteTitle = () => {
       <h1 className={className}>
         <TitleText />
       </h1>}
-      <h2 className={titles.subHeadline}>Archive of Native American Enslavement</h2>
+      <h2 className={titles.subHeadline}>{TITLES.subtitle}</h2>
     </header>
   )
 }

--- a/components/TitleText.tsx
+++ b/components/TitleText.tsx
@@ -1,11 +1,15 @@
 
 import titles from '../styles/component/Title.module.scss'
+import { split } from '../lib/utils';
+import { TITLES } from '../lib/constants';
 
 export default function TitleText() {
+  let bound = split(TITLES.title, 0, 12);
+  let unbound = split(TITLES.title, 13)
   return (
     <>
-    <span className={titles.main}>Native Bound</span>
-    <span className={titles.unbound}>Unbound</span>
+    <span className={titles.main}>{bound}</span>
+    <span className={titles.unbound}>{unbound}</span>
     </>
   )
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,8 @@
+// DONE: Move the split function out to its helper lib...
+
+// String Splitter used on the title... because! I can JavaScript! and baby steps w/ TS!!!
+export function split(string: string, pos1: number, pos2?: number) {
+  let splitString = string.slice(pos1, pos2);
+    return splitString
+  }
+  


### PR DESCRIPTION
closes #4 
- adds a utility for splitting text, use this on the title
- takes advantage of using a constants file; because the internest says it must be so...